### PR TITLE
Solve hook error for windows user

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,5 @@
 #!/bin/sh
 echo "executing post-commit"
-exit 0
 
 HAS_ISSUES=0
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,4 @@
 #!/bin/sh
-echo "executing post-commit"
 
 HAS_ISSUES=0
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,7 @@
+#!/bin/sh
+echo "executing post-commit"
+exit 0
+
 HAS_ISSUES=0
 
 for file in $(git diff --name-only --staged); do


### PR DESCRIPTION
# Summary
I faced a problem with post-commit hook in Windows. This script solved it. [In SVN world, while in *nix we have a "pre-commit" script and in Windows we had "pre-commit.bat" and SVN automatically picked up the bat file in Windows. Git doesn't seem to pick up a pre-commit.bat ( or any hook ) and adding the shebang to the hook file worked.](https://stackoverflow.com/questions/5697210/msysgit-error-with-hooks-git-error-cannot-spawn-git-hooks-post-commit-no-su)

